### PR TITLE
pipenv-open: fix finding python

### DIFF
--- a/pipenv.el
+++ b/pipenv.el
@@ -278,8 +278,9 @@ or (if none is given), installs all packages."
   (let* ((template "%s -c 'import %s; print(%s.__file__)'")
          (replacements '(("pyo" . "py") ("pyc" . "py") ("pyd" . "py")))
          (suffix "__init__.py")
+         (python-path (executable-find python-shell-interpreter))
          (response (shell-command-to-string
-                    (format template python-shell-interpreter module module)))
+                    (format template python-path module module)))
          (real-path (s-with response
                       (s-chomp)
                       (s-trim)


### PR DESCRIPTION
The first commit in this PR finds python with executable-find.  Otherwise, shell-command-to-string would run everything in a /bin/bash shell which will try finding Python in $PATH and not in exec-path set up by pipenv.el.

The second commit adds a `pipenv--check-output` function to be used in `pipenv-open` instead of `shell-command-to-string`.