### PR TITLE
Fix [#31], add prefix key customization

### DIFF
--- a/pipenv.el
+++ b/pipenv.el
@@ -89,6 +89,11 @@
   :type 'function
   :group 'pipenv)
 
+(defcustom pipenv-keymap-prefix (kbd "C-c C-p")
+  "Pipenv keymap prefix."
+  :group 'pipenv
+  :type 'string)
+
 ;;
 ;; Helper functions internal to the package.
 ;;
@@ -421,18 +426,27 @@ and open a Pipenv shell and a Python interpreter."
 ;; Core Emacs integration.
 ;;
 
+(defvar pipenv-command-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "a") 'pipenv-activate)
+    (define-key map (kbd "d") 'pipenv-deactivate)
+    (define-key map (kbd "s") 'pipenv-shell)
+    (define-key map (kbd "o") 'pipenv-open)
+    (define-key map (kbd "i") 'pipenv-install)
+    (define-key map (kbd "u") 'pipenv-uninstall)
+    map))
+
+(defvar pipenv-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map pipenv-keymap-prefix pipenv-command-map)
+    map)
+  "Keymap for pipenv mode.")
+
 ;;;###autoload
 (define-minor-mode pipenv-mode
   "Minor mode for Pipenv."
   :lighter " Pipenv"
-  :keymap (let ((map (make-sparse-keymap)))
-            (define-key map (kbd "C-c C-p a") 'pipenv-activate)
-            (define-key map (kbd "C-c C-p d") 'pipenv-deactivate)
-            (define-key map (kbd "C-c C-p s") 'pipenv-shell)
-            (define-key map (kbd "C-c C-p o") 'pipenv-open)
-            (define-key map (kbd "C-c C-p i") 'pipenv-install)
-            (define-key map (kbd "C-c C-p u") 'pipenv-uninstall)
-            map))
+  :keymap pipenv-mode-map)
 
 (provide 'pipenv)
 


### PR DESCRIPTION
Now, users can customize prefix key by adding following code before loading the
package:

    (setq pipenv-keymap-prefix (kbd "C-x C-p"))