### PR TITLE
Fix pipenv-activate hanging

### DIFF
--- a/pipenv.el
+++ b/pipenv.el
@@ -344,10 +344,12 @@ to latest compatible versions."
   "Activate the Python version from Pipenv. Return nil if no project."
   (interactive)
   (when (pipenv-project?)
-    (pipenv--force-wait (pipenv-venv))
-    (pipenv--push-venv-executables-to-exec-path)
-    (when (and (featurep 'flycheck) pipenv-with-flycheck)
-      (pipenv-activate-flycheck))
+    (let ((pipenv-venv-proc (pipenv-venv)))
+      (set-process-sentinel pipenv-venv-proc
+                            (lambda (proc event)
+                              (pipenv--push-venv-executables-to-exec-path)
+                              (when (and (featurep 'flycheck) pipenv-with-flycheck)
+                                (pipenv-activate-flycheck)))))
     t))
 
 (defun pipenv-deactivate ()


### PR DESCRIPTION
Sometimes the process status for (pipenv-venv) never leaves the "run" state and
therefore the loop in (pipenv--force-wait) spins forever and causes
the (pipenv-activate) to hang.  This commit replaces the wait loop with a process
sentinel that is called when (pipenv-venv) returns inside of (pipenv-activate)

Fixes #25