### PR TITLE
Fix pipenv-activate hanging 

### DIFF
--- a/pipenv.el
+++ b/pipenv.el
@@ -115,6 +115,9 @@
 
 (defun pipenv--force-wait (process)
   "Block until PROCESS exits successfully."
+  ;; Adding a sit-for in a sentinel seems to give the process time to update its
+  ;; status which can help process-live-p from ever returning true
+  (set-process-sentinel process (lambda (proc event) (sit-for 0.1)))
   (while (process-live-p process)
     (sit-for 0.1 t)))
 


### PR DESCRIPTION
In some cases (pipenv--force-wait) can hang where (process-live-p) always return true. If we had a sentinel to the process with a slight delay when the status changes then it seems to give the process enough time to update and (process-live-p) will return true when it dies.

Fixes #25 