### PR TITLE
Improve cleanup response

### DIFF
--- a/pipenv.el
+++ b/pipenv.el
@@ -105,7 +105,7 @@
 
 (defun pipenv--clean-response (response)
   "Clean up RESPONSE from shell command."
-  (s-chomp response))
+  (nth 0 (s-split "," (replace-regexp-in-string "[^[:print:]]" "," response))))
 
 (defun pipenv--force-list (argument)
   "Force ARGUMENT to a list."


### PR DESCRIPTION
The modification removes unnecessary characters (i.e. escape character like "^[[0m" to reset color) sometimes remain at the end of response from `pipenv --venv` command which disable to set `python-shell-virtualenv-root`. 