### PR TITLE
Better flycheck integration

### DIFF
--- a/Cask
+++ b/Cask
@@ -8,4 +8,5 @@
 
 (development
  (depends-on "ert-runner")
- (depends-on "package-lint"))
+ (depends-on "package-lint")
+ (depends-on "flycheck"))

--- a/README.org
+++ b/README.org
@@ -6,12 +6,12 @@
 [[https://melpa.org/#/pipenv][file:https://melpa.org/packages/pipenv-badge.svg]]
 
 
-A [[https://docs.pipenv.org][Pipenv]] porcelain inside Emacs.
+A [[https://pipenv.readthedocs.io/en/latest/][Pipenv]] porcelain inside Emacs.
 
 ** Overview
 
-[[https://docs.pipenv.org][Pipenv]] is now the officially recommended Python packaging tool. It manages virtual environments, adds and removes packages, and enables deterministic build dependencies, has =Pipfile= to finally replace all other =requirements.txt= hacks. Yay for Pipenv.
 
+[[https://pipenv.readthedocs.io/en/latest/][Pipenv]] is a tool that aims to bring the best of all packaging worlds to the Python world. It manages virtual environments, adds and removes packages, and enables deterministic build dependencies.
 =pipenv.el= makes Pipenv a first-class citizen in your Emacs-driven Python development workflow with a range of interactive commands wrapping the Pipenv, a minor mode to accompany =python-mode= with a keymap for the most useful commands, and a high-level =pipenv-activate= / =pipenv-deactivate= interface for virtual environment integration with your Emacs session.
 
 ** Contributing

--- a/pipenv.el
+++ b/pipenv.el
@@ -387,13 +387,26 @@ to latest compatible versions."
 ;; Integration with 3rd party packages.
 ;;
 
+(defun pipenv-verify-python-checkers ()
+  "Manually verify checkers for python-mode"
+  (setq checkers (flycheck-defined-checkers 'modes))
+  (while checkers
+    (setq checker (car checkers))
+    (when (memq 'python-mode (flycheck-checker-get checker 'modes))
+      (setq flycheck-disabled-checkers (remq checker flycheck-disabled-checkers))
+      (setq flycheck-enabled-checkers (remq checker flycheck-enabled-checkers))
+      (flycheck-may-use-checker checker))
+    (setq checkers (cdr checkers))))
+
 (defun pipenv-activate-flycheck ()
   "Activate integration of Pipenv with Flycheck."
-  (setq flycheck-executable-find #'pipenv-executable-find))
+  (setq flycheck-executable-find #'pipenv-executable-find)
+  (pipenv-verify-python-checkers))
 
 (defun pipenv-deactivate-flycheck ()
   "Deactivate integration of Pipenv with Flycheck."
-  (setq flycheck-executable-find #'executable-find))
+  (setq flycheck-executable-find #'flycheck-default-executable-find)
+  (pipenv-verify-python-checkers))
 
 (defun pipenv-activate-projectile ()
   "Activate integration of Pipenv with Projectile."

--- a/pipenv.el
+++ b/pipenv.el
@@ -178,7 +178,10 @@
    :command command
    :coding 'utf-8-unix
    :filter filter
-   :sentinel sentinel))
+   :sentinel sentinel
+   :connection-type 'pipe
+  )
+)
 
 (defun pipenv--command (args)
   "Call Pipenv with ARGS and the default filter stack."

--- a/pipenv.el
+++ b/pipenv.el
@@ -387,7 +387,7 @@ to latest compatible versions."
 ;; Integration with 3rd party packages.
 ;;
 
-(defun pipenv-verify-python-checkers ()
+(defun pipenv--verify-python-checkers ()
   "Manually verify checkers for python-mode"
   (setq checkers (flycheck-defined-checkers 'modes))
   (while checkers
@@ -401,12 +401,12 @@ to latest compatible versions."
 (defun pipenv-activate-flycheck ()
   "Activate integration of Pipenv with Flycheck."
   (setq flycheck-executable-find #'pipenv-executable-find)
-  (pipenv-verify-python-checkers))
+  (pipenv--verify-python-checkers))
 
 (defun pipenv-deactivate-flycheck ()
   "Deactivate integration of Pipenv with Flycheck."
   (setq flycheck-executable-find #'flycheck-default-executable-find)
-  (pipenv-verify-python-checkers))
+  (pipenv--verify-python-checkers))
 
 (defun pipenv-activate-projectile ()
   "Activate integration of Pipenv with Projectile."

--- a/test/pipenv-test.el
+++ b/test/pipenv-test.el
@@ -3,6 +3,7 @@
 (require 'ert)
 (require 'f)
 (require 's)
+(require 'flycheck)
 
 (load (f-expand "pipenv.el" default-directory))
 
@@ -141,3 +142,16 @@
   (should (s-equals? "python" python-shell-interpreter))
   (let ((venv-executables (pipenv--get-executables-dir)))
     (should (not (member venv-executables exec-path)))))
+
+(ert-deftest flycheck-integration ()
+  (cd existing-project)
+  (pipenv--force-wait (pipenv-install "flake8"))
+  (find-file "some.py")
+  (flycheck-mode)
+  (should-not (flycheck-may-use-checker 'python-flake8))
+  (pipenv-activate)
+  (should-not (flycheck-disabled-checker-p 'python-flake8))
+  (pipenv-deactivate)
+  (should (flycheck-disabled-checker-p 'python-flake8))
+  (pipenv--force-wait (pipenv-uninstall "flake8"))
+)

--- a/test/pipenv-test.el
+++ b/test/pipenv-test.el
@@ -54,10 +54,10 @@
   (should (s-contains? "No Pipfile present at project home" pipenv-process-response))
 
   (pipenv--force-wait (pipenv-venv))
-  (should (s-contains? "No virtualenv has been created" pipenv-process-response))
+  (should (s-contains? "Aborted!" pipenv-process-response))
 
   (pipenv--force-wait (pipenv-py))
-  (should (s-contains? "No project found" pipenv-process-response))
+  (should (s-contains? "location not created nor specified" pipenv-process-response))
 
   (should (eq nil python-shell-virtualenv-path))
   (should (eq nil python-shell-virtualenv-root))


### PR DESCRIPTION
This PR handles with https://github.com/pwalsh/pipenv.el/issues/19 and also addresses https://github.com/pwalsh/pipenv.el/issues/43 providing a somehow more elegant solution than https://github.com/pwalsh/pipenv.el/pull/46.
This PR mainly follows a suggested workaround from https://github.com/flycheck/flycheck/issues/1542 - it just reverifies Python checkers availability after pipenv activate/deactivate.
This PR was tested manually and with CircleCI (a new test case was added).