### PR TITLE
pyvenv integration

### DIFF
--- a/Cask
+++ b/Cask
@@ -5,6 +5,7 @@
 
 (depends-on "s" "1.12.0")
 (depends-on "f" "0.19.0")
+(depends-on "pyvenv" "1.20.0")
 
 (development
  (depends-on "ert-runner")

--- a/README.org
+++ b/README.org
@@ -12,6 +12,7 @@ A [[https://pipenv.readthedocs.io/en/latest/][Pipenv]] porcelain inside Emacs.
 
 
 [[https://pipenv.readthedocs.io/en/latest/][Pipenv]] is a tool that aims to bring the best of all packaging worlds to the Python world. It manages virtual environments, adds and removes packages, and enables deterministic build dependencies.
+
 =pipenv.el= makes Pipenv a first-class citizen in your Emacs-driven Python development workflow with a range of interactive commands wrapping the Pipenv, a minor mode to accompany =python-mode= with a keymap for the most useful commands, and a high-level =pipenv-activate= / =pipenv-deactivate= interface for virtual environment integration with your Emacs session.
 
 ** Contributing
@@ -61,7 +62,7 @@ Here is an example of configuration with =use-package=.
 
 In addition to providing the majority of Pipenv commands, there are several custom functions available in =pipenv.el=. The most useful are =pipenv-activate= and =pipenv-deactivate=, which are used to manage the Python virtual environment for the current Emacs session.
 
-=pipenv-activate= sets the variable =python-shell-virtualenv-root= to that of the Pipenv project currently being visited, and =pipenv-deactivate= sets it back to the Emacs default.
+=pipenv-activate= calls =pyvenv-activate= and sets the variable =python-shell-virtualenv-root= to that of the Pipenv project currently being visited, and =pipenv-deactivate= sets it back to the Emacs default and also calls =pyvenv-deactivate=.
 
 *** Minor mode
 
@@ -103,3 +104,6 @@ You can set your own function to =pipenv-projectile-after-switch-function= to cu
 #+BEGIN_SRC elisp
 (setq pipenv-projectile-after-switch-function #'pipenv-projectile-after-switch-extended)
 #+END_SRC
+**** Pyvenv
+
+=pipenv.el= relies on [[https://stable.melpa.org/#/pyvenv/][pyvenv]] to switch between different virtual environments (=pipenv-activate= and =pipenv-deactivate=).

--- a/pipenv.el
+++ b/pipenv.el
@@ -30,6 +30,7 @@
 (require 'python)
 (require 's)
 (require 'subr-x)
+(require 'pyvenv)
 
 (defgroup pipenv nil
   "A Pipenv porcelain."
@@ -159,16 +160,6 @@
     (concat
      (file-name-as-directory python-shell-virtualenv-root)
      (if (eq system-type 'windows-nt) "Scripts" "bin"))))
-
-(defun pipenv--push-venv-executables-to-exec-path ()
-  "Push the directory of executables in an active virtual environment to PATH."
-  (when-let ((venv-executables (pipenv--get-executables-dir)))
-    (push venv-executables exec-path)))
-
-(defun pipenv--pull-venv-executables-from-exec-path ()
-  "Pull the directory of executables in an active virtual environment from PATH."
-  (when-let ((venv-executables (pipenv--get-executables-dir)))
-    (setq exec-path (delete venv-executables exec-path))))
 
 (defun pipenv--make-pipenv-process (command &optional filter sentinel)
   "Make a Pipenv process from COMMAND; optional custom FILTER or SENTINEL."
@@ -348,7 +339,7 @@ to latest compatible versions."
   (interactive)
   (when (pipenv-project?)
     (pipenv--force-wait (pipenv-venv))
-    (pipenv--push-venv-executables-to-exec-path)
+    (pyvenv-activate (directory-file-name python-shell-virtualenv-root))
     (when (and (featurep 'flycheck) pipenv-with-flycheck)
       (pipenv-activate-flycheck))
     t))
@@ -356,7 +347,7 @@ to latest compatible versions."
 (defun pipenv-deactivate ()
   "Deactivate the Python version from Pipenv; back to defaults."
   (interactive)
-  (pipenv--pull-venv-executables-from-exec-path)
+  (pyvenv-deactivate)
   (setq python-shell-virtualenv-root nil)
   (when (and (featurep 'flycheck) pipenv-with-flycheck)
     (pipenv-deactivate-flycheck))


### PR DESCRIPTION
# What changes are proposed in this PR

* use pyvenv to switch virtualenvs
* remove pipenv.el original functions for switching virtualenvs

# How this PR was tested

* manually (switching projects and running Python tests by C-c C-t)
* in CircleCI (existing tests were extended)

# What issues/PRs are related to this PR

Pyvenv integration was proposed in https://github.com/pwalsh/pipenv.el/issues/22, https://github.com/pwalsh/pipenv.el/issues/23 was related with inability to run tests, and https://github.com/pwalsh/pipenv.el/pull/42 proposed another solution (extending pipenv functions for switching venvs, not removing them).