### PR TITLE
Handle wider variety of output when parsing a pipenv process response

### DIFF
--- a/pipenv.el
+++ b/pipenv.el
@@ -106,7 +106,8 @@
 
 (defun pipenv--clean-response (response)
   "Clean up RESPONSE from shell command."
-  (s-chomp response))
+  (car
+   (s-lines response)))
 
 (defun pipenv--force-list (argument)
   "Force ARGUMENT to a list."


### PR DESCRIPTION
On my machine calling `pipenv --venv` returns the path along with some extra bytes that are not removed by `s-chomp`. Downstream the `pipenv` package cannot determine the directory (with these extra errorneous bytes) and fails.

This PR makes the response cleaning function more tolerant of outputs from this command by simply taking the first full line of output.