### PR TITLE
fix package-lint/byte-compiler/check-doc warnings

### DIFF
--- a/pipenv.el
+++ b/pipenv.el
@@ -179,11 +179,6 @@
 ;; Interactive commands that implement the Pipenv interface in Emacs.
 ;;
 
-(defun pipenv-update ()
-  "Update Pipenv and pip to latest."
-  (interactive)
-  (pipenv--command (list "--update")))
-
 (defun pipenv-where ()
   "Return path to project home directory, or a message if not in a Pipenv project."
   (interactive)

--- a/pipenv.el
+++ b/pipenv.el
@@ -1,11 +1,11 @@
-;;; pipenv.el --- A Pipenv porcelain.  -*- lexical-binding: t; -*-
+;;; pipenv.el --- A Pipenv porcelain  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2017-2018 by Paul Walsh
 
 ;; Author: Paul Walsh <paulywalsh@gmail.com>
 ;; URL: https://github.com/pwalsh/pipenv.el
 ;; Version: 0.0.1-beta
-;; Package-Requires: ((emacs "25.1")(f "0.19.0")(s "1.12.0")(pyvenv "1.20"))
+;; Package-Requires: ((emacs "25.1") (f "0.19.0") (s "1.12.0") (pyvenv "1.20"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -135,7 +135,7 @@
       ;; Interpret ANSI escape sequences from Pipenv
       (ansi-color-apply-on-region (point-min) (point-max)))))
 
-(defun pipenv--process-filter-variable-insert(process response)
+(defun pipenv--process-filter-variable-insert (process response)
   "Filter for PROCESS, which sets several global variables based on RESPONSE."
   (when (and
          (s-equals? (nth 0 (last (process-command process))) "--venv")
@@ -166,14 +166,13 @@
    :coding 'utf-8-unix
    :filter filter
    :sentinel sentinel
-   :connection-type 'pipe
-  ))
+   :connection-type 'pipe))
 
 (defun pipenv--command (args)
   "Call Pipenv with ARGS and the default filter stack."
   (let ((command (cons pipenv-executable args))
         (filter 'pipenv--process-filter)
-	(sentinel 'pipenv--messaging-sentinel))
+        (sentinel 'pipenv--messaging-sentinel))
     (pipenv--make-pipenv-process command filter sentinel)))
 
 ;;
@@ -257,7 +256,7 @@ markers provided in Pipfile."
   (pipenv--command (list "graph")))
 
 (defun pipenv-install(packages)
-  "Installs PACKAGES and adds them to Pipfile, \
+  "Installs PACKAGES and adds them to Pipfile,
 or (if none is given), installs all packages."
   (interactive "sWhich Python packages should be installed (separate with space)? ")
   (pipenv--command (cons "install" (pipenv--force-list packages))))
@@ -320,7 +319,7 @@ A poor-man's equivalent of subprocess.check_output in Python."
     (comint-clear-buffer)))
 
 (defun pipenv-uninstall (packages)
-  "Uninstalls PACKAGES and removes from Pipfile."
+  "Uninstall PACKAGES and remove from Pipfile."
   (interactive "sWhich Python packages should be uninstalled (separate with space)? ")
   (pipenv--command (cons "uninstall" (pipenv--force-list packages))))
 
@@ -335,7 +334,7 @@ to latest compatible versions."
 ;;
 
 (defun pipenv-activate ()
-  "Activate the Python version from Pipenv. Return nil if no project."
+  "Activate the Python version from Pipenv.  Return nil if no project."
   (interactive)
   (when (pipenv-project?)
     (pipenv--force-wait (pipenv-venv))
@@ -379,16 +378,20 @@ to latest compatible versions."
 ;; Integration with 3rd party packages.
 ;;
 
+(defvar flycheck-disabled-checkers)
+(defvar flycheck-enabled-checkers)
+(defvar flycheck-executable-find)
+
 (defun pipenv--verify-python-checkers ()
-  "Manually verify checkers for python-mode"
-  (setq checkers (flycheck-defined-checkers 'modes))
-  (while checkers
-    (setq checker (car checkers))
-    (when (memq 'python-mode (flycheck-checker-get checker 'modes))
-      (setq flycheck-disabled-checkers (remq checker flycheck-disabled-checkers))
-      (setq flycheck-enabled-checkers (remq checker flycheck-enabled-checkers))
-      (flycheck-may-use-checker checker))
-    (setq checkers (cdr checkers))))
+  "Manually verify checkers for `python-mode'."
+  (let ((checkers (flycheck-defined-checkers 'modes)))
+    (while checkers
+      (let ((checker (car checkers)))
+        (when (memq 'python-mode (flycheck-checker-get checker 'modes))
+          (setq flycheck-disabled-checkers (remq checker flycheck-disabled-checkers))
+          (setq flycheck-enabled-checkers (remq checker flycheck-enabled-checkers))
+          (flycheck-may-use-checker checker)))
+      (setq checkers (cdr checkers)))))
 
 (defun pipenv-activate-flycheck ()
   "Activate integration of Pipenv with Flycheck."

--- a/pipenv.el
+++ b/pipenv.el
@@ -140,8 +140,7 @@
   (when (and
          (s-equals? (nth 0 (last (process-command process))) "--venv")
          (f-directory? response))
-    (setq python-shell-virtualenv-root response))
-  (setq pipenv-process-response response))
+    (setq python-shell-virtualenv-root response)))
 
 (defun pipenv--process-filter (process response)
   "Pipenv default filter stack PROCESS and RESPONSE handling."


### PR DESCRIPTION
### before
```
 pipenv.el     1   1 warning         The package summary should not end with a period. (emacs-lisp-package)
 pipenv.el   139     info            Probably "sets" should be imperative "set" (emacs-lisp-checkdoc)
 pipenv.el   144   9 warning         assignment to free variable ‘pipenv-process-response’ (emacs-lisp)
 pipenv.el   170   3 warning         Closing parens should not be wrapped onto new lines. (emacs-lisp-package)
 pipenv.el   260     info            Probably "Installs" should be imperative "Install" (emacs-lisp-checkdoc)
 pipenv.el   323     info            Probably "removes" should be imperative "remove" (emacs-lisp-checkdoc)
 pipenv.el   327   8 warning         function ‘pipenv-update’ defined multiple times in this file (emacs-lisp)
 pipenv.el   338     info            There should be two spaces after a period (emacs-lisp-checkdoc)
 pipenv.el   383     info            First sentence should end with punctuation (emacs-lisp-checkdoc)
 pipenv.el   383     info            Lisp symbol ‘python-mode’ should appear in quotes (emacs-lisp-checkdoc)
 pipenv.el   385  10 warning         assignment to free variable ‘checkers’ (emacs-lisp)
 pipenv.el   386  24 warning         reference to free variable ‘checkers’ (emacs-lisp)
 pipenv.el   387  31 warning         reference to free variable ‘checker’ (emacs-lisp)
 pipenv.el   388  54 warning         reference to free variable ‘flycheck-disabled-checkers’ (emacs-lisp)
 pipenv.el   388  54 warning         assignment to free variable ‘flycheck-disabled-checkers’ (emacs-lisp)
 pipenv.el   389  13 warning         reference to free variable ‘flycheck-enabled-checkers’ (emacs-lisp)
 pipenv.el   389  53 warning         assignment to free variable ‘flycheck-enabled-checkers’ (emacs-lisp)
 pipenv.el   390  33 warning         assignment to free variable ‘checker’ (emacs-lisp)
 pipenv.el   395   9 warning         assignment to free variable ‘flycheck-executable-find’ (emacs-lisp)
 pipenv.el   400   9 warning         assignment to free variable ‘flycheck-executable-find’ (emacs-lisp)
 pipenv.el   463   1 warning         the following functions are not known to be defined: flycheck-defined-checkers, flycheck-checker-get, flycheck-may-use-checker, flycheck-default-executable-find (emacs-lisp)
```

### after
```
 pipenv.el   139     info            Probably "sets" should be imperative "set" (emacs-lisp-checkdoc)
 pipenv.el   144   9 warning         assignment to free variable ‘pipenv-process-response’ (emacs-lisp)
 pipenv.el   259     info            First line is not a complete sentence (emacs-lisp-checkdoc)
 pipenv.el   259     info            Probably "Installs" should be imperative "Install" (emacs-lisp-checkdoc)
 pipenv.el   326   8 warning         function ‘pipenv-update’ defined multiple times in this file (emacs-lisp)
 pipenv.el   466   1 warning         the following functions are not known to be defined: flycheck-defined-checkers, flycheck-checker-get, flycheck-may-use-checker, flycheck-default-executable-find (emacs-lisp)
```

@pwalsh
How to `function ‘pipenv-update’ defined multiple times in this file (emacs-lisp)`
and `assignment to free variable ‘pipenv-process-response’ (emacs-lisp)` handle?