### PR TITLE
Import env vars from .env if exists

### DIFF
--- a/Cask
+++ b/Cask
@@ -6,6 +6,7 @@
 (depends-on "s" "1.12.0")
 (depends-on "f" "0.19.0")
 (depends-on "pyvenv" "1.20.0")
+(depends-on "load-env-vars" "0.0.2")
 
 (development
  (depends-on "ert-runner")

--- a/pipenv.el
+++ b/pipenv.el
@@ -5,7 +5,7 @@
 ;; Author: Paul Walsh <paulywalsh@gmail.com>
 ;; URL: https://github.com/pwalsh/pipenv.el
 ;; Version: 0.0.1-beta
-;; Package-Requires: ((emacs "25.1") (s "1.12.0") (pyvenv "1.20"))
+;; Package-Requires: ((emacs "25.1") (s "1.12.0") (pyvenv "1.20") (load-env-vars "0.0.2"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -337,12 +337,16 @@ to latest compatible versions."
 ;; High-level interactive commands enabled by the Pipenv interface.
 ;;
 
+
 (defun pipenv-activate ()
   "Activate the Python version from Pipenv.  Return nil if no project."
   (interactive)
-  (when (pipenv-project?)
+  (when-let ((root (pipenv-project?)))
     (pipenv--force-wait (pipenv-venv))
     (pyvenv-activate (directory-file-name python-shell-virtualenv-root))
+    (let ((env-file (expand-file-name ".env" root)))
+      (when (file-exists-p env-file)
+        (load-env-vars env-file)))
     (when (and (featurep 'flycheck) pipenv-with-flycheck)
       (pipenv-activate-flycheck))
     t))


### PR DESCRIPTION
Pipenv imports .env file. Would be nice if pipenv.el do the same. A simple PR to do just that. 