### PR TITLE
Don't use f.el function

### DIFF
--- a/Cask
+++ b/Cask
@@ -4,7 +4,6 @@
 (package "pipenv" "0.0.1-beta" "A Pipenv porcelain inside Emacs.")
 
 (depends-on "s" "1.12.0")
-(depends-on "f" "0.19.0")
 (depends-on "pyvenv" "1.20.0")
 (depends-on "load-env-vars" "0.0.2")
 

--- a/pipenv.el
+++ b/pipenv.el
@@ -179,7 +179,7 @@
 (defun pipenv--f-parent (path)
   "Return the parent directory to PATH.  see `f-parent'."
   (let ((parent (file-name-directory
-                 (directory-file-name (f-expand path default-directory)))))
+                 (directory-file-name (expand-file-name path default-directory)))))
     (if (file-name-absolute-p path)
         (directory-file-name parent)
       (file-relative-name parent))))


### PR DESCRIPTION
https://github.com/pwalsh/pipenv.el/pull/57 removed `f.el` dependency but pipenv.el still uses a `f.el` function.